### PR TITLE
combine highlights for virtual text

### DIFF
--- a/lua/virtualtypes.lua
+++ b/lua/virtualtypes.lua
@@ -10,7 +10,7 @@ local M = {}
 local set_virtual_text
 if vim.api.nvim_call_function('exists', {'*nvim_buf_set_extmark'}) == 1 then
   set_virtual_text = function(buffer_number, ns, start_line, msg)
-    api.nvim_buf_set_extmark(buffer_number, ns, start_line, 1, { virt_text = { msg } } )
+    api.nvim_buf_set_extmark(buffer_number, ns, start_line, 1, { virt_text = { msg }, hl_mode = 'combine' } )
   end
 else
   set_virtual_text = function(buffer_number, ns, start_line, msg)


### PR DESCRIPTION
Before: There's a break in the CursorLine under the virtual text

<img width="486" alt="Screenshot 2022-01-07 at 23 48 41" src="https://user-images.githubusercontent.com/214264/148621517-2fe011e8-ef95-47b5-ae6a-c92506e0d118.png">

After: CursorLine and TypeAnnot highlights are combined
<img width="486" alt="Screenshot 2022-01-07 at 23 48 03" src="https://user-images.githubusercontent.com/214264/148621524-10e0eccd-06ce-4461-aeae-8a28ad281fcc.png">

