### PR TITLE
Fix DisableVirtualTypes by adding buffer_number.

### DIFF
--- a/lua/virtualtypes.lua
+++ b/lua/virtualtypes.lua
@@ -39,6 +39,7 @@ function M.enable()
 end
 
 function M.disable()
+  local buffer_number = api.nvim_get_current_buf()
   api.nvim_buf_clear_namespace(buffer_number, virtual_types_ns, 0, -1)
   is_enabled = false
 end


### PR DESCRIPTION
```:DisableVirtualTypes``` was throwing the following error:

```E5108: Error executing lua .../pack/paqs/start/virtual-types.nvim/lua/virtualtypes.lua:43: Expected Lua number
stack traceback:
        [C]: in function 'nvim_buf_clear_namespace'
        .../pack/paqs/start/virtual-types.nvim/lua/virtualtypes.lua:43: in function 'disable'
        [string ":lua"]:1: in main chunk
```